### PR TITLE
chore: add optional type params in TS type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 import KefirDefault from 'kefir';
 import * as Kefir from 'kefir';
 
-export default function kefirCast(_Kefir: typeof Kefir | typeof KefirDefault, input: any): Kefir.Observable<any,any>;
+export default function kefirCast<T = any, U = any>(_Kefir: typeof Kefir | typeof KefirDefault, input: T): Kefir.Observable<T, U>;


### PR DESCRIPTION
In InboxSDK/InboxSDK, we have a number of spots where kefir-cast is inadvertently throwing away type information. Adding optional type params allows us to plumb through the underlying type from before the cast.
